### PR TITLE
Add tests for login/logout functionality

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,20 @@
     </dependency>
 
     <dependency>
+        <groupId>com.google.appengine</groupId>
+        <artifactId>appengine-testing</artifactId>
+        <version>1.9.80</version>
+        <scope>test</scope>
+    </dependency>
+
+    <dependency>
+        <groupId>com.google.appengine</groupId>
+        <artifactId>appengine-api-stubs</artifactId>
+        <version>1.9.80</version>
+        <scope>test</scope>
+    </dependency>
+
+    <dependency>
         <groupId>com.amihaiemil.web</groupId>
         <artifactId>eo-yaml</artifactId>
         <version>5.1.2</version>

--- a/src/main/java/com/google/sps/login/Authentication.java
+++ b/src/main/java/com/google/sps/login/Authentication.java
@@ -10,9 +10,8 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
-// limitations under the License.
 
-package com.google.sps.data;
+package com.google.sps.login;
 
 // Authentication class that stores whether the user is logged in and the redirect link
 public final class Authentication {
@@ -23,5 +22,13 @@ public final class Authentication {
     public Authentication(boolean loggedIn, String redirectLink) {
         this.loggedIn = loggedIn;
         this.redirectLink = redirectLink;
+    }
+
+    public boolean getLoggedIn() {
+        return loggedIn;
+    }
+
+    public String getRedirectLink() {
+        return redirectLink;
     }
 }

--- a/src/main/java/com/google/sps/login/Login.java
+++ b/src/main/java/com/google/sps/login/Login.java
@@ -12,19 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.google.sps.servlets;
+package com.google.sps.login;
 
 import com.google.appengine.api.users.UserService;
 import com.google.appengine.api.users.UserServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.KeyFactory;
 import com.google.gson.Gson;
-import com.google.sps.data.Authentication;
+import com.google.sps.login.Authentication;
 import java.io.IOException;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.util.ArrayList;
-
 
 @WebServlet("/login")
 public class Login extends HttpServlet {
@@ -33,35 +33,34 @@ public class Login extends HttpServlet {
     private static final String REDIRECT_LOGIN = "/";
     private static final String REDIRECT_LOGOUT = "/";
     
-    // Print json of whether user is logged in and the respective login/logout link
+    // Passes in the actual userService to getAuthentication
     @Override
     public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
 
-        Authentication auth;
-        
-        response.setContentType("application/json");
-
         UserService userService = UserServiceFactory.getUserService();
+        
+        // Get the login status and link
+        Authentication auth = getAuthentication(userService);
+
+        response.getWriter().println(new Gson().toJson(auth));
+
+    }
+
+    // Return Authentication class that includes login status and login/logout link
+    public Authentication getAuthentication(UserService userService) {
+        Authentication auth;
+
         if (userService.isUserLoggedIn()) {
             String logoutUrl = userService.createLogoutURL(REDIRECT_LOGOUT);
-            String userEmail = userService.getCurrentUser().getEmail();
 
             auth = new Authentication(true, logoutUrl);
-
-            Gson gson = new Gson();
-            String json = gson.toJson(auth);
-
-            response.getWriter().println(json);
         }
         else {
             String loginUrl = userService.createLoginURL(REDIRECT_LOGIN);
 
             auth = new Authentication(false, loginUrl);
-
-            Gson gson = new Gson();
-            String json = gson.toJson(auth);
-
-            response.getWriter().println(json);
         }
+
+        return auth;
     }
 }

--- a/src/test/java/com/google/sps/login/LoginTest.java
+++ b/src/test/java/com/google/sps/login/LoginTest.java
@@ -1,0 +1,96 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.sps.login;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import com.google.appengine.api.users.UserService;
+import com.google.appengine.api.users.UserServiceFactory;
+import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+import com.google.appengine.tools.development.testing.LocalUserServiceTestConfig;
+
+@RunWith(JUnit4.class)
+public final class LoginTest {
+
+    private LocalServiceTestHelper helper;
+	private Login login;
+
+    @Before
+    public void setUp() {
+        // instantiate Login class
+        login = new Login();
+    }
+
+    @Test
+    public void testIsLoggedIn() {
+        // set up testing environment where user is logged in
+        setUpHelper(true);
+
+        UserService userService = UserServiceFactory.getUserService();
+
+        // create expected authentication class that's logged in
+        String expectedLogoutURL = userService.createLogoutURL("/");
+        Authentication authExpected = new Authentication(true, expectedLogoutURL);
+
+        // get actual return from Login.java
+        Authentication authActual = login.getAuthentication(userService);
+
+        // check values of expected and actual to make sure they align
+        Assert.assertEquals(authExpected.getLoggedIn(), authActual.getLoggedIn());
+        Assert.assertEquals(authExpected.getRedirectLink(), authActual.getRedirectLink());
+
+        // tear down testing environment
+        helper.tearDown();
+    }
+
+    @Test
+    public void testIsLoggedOut() {
+        // set up testing environment where user is logged out
+        setUpHelper(false);
+
+        UserService userService = UserServiceFactory.getUserService();
+
+        // create expected authentication class that's logged in
+        String expectedLogoutURL = userService.createLoginURL("/");
+        Authentication authExpected = new Authentication(false, expectedLogoutURL);
+
+        // get actual return from Login.java
+        Authentication authActual = login.getAuthentication(userService);
+
+        // check values of expected and actual to make sure they align
+        Assert.assertEquals(authExpected.getLoggedIn(), authActual.getLoggedIn());
+        Assert.assertEquals(authExpected.getRedirectLink(), authActual.getRedirectLink());
+
+        // tear down testing environment
+        helper.tearDown();
+    }
+
+    // set up helper function depending on login status
+    public void setUpHelper(boolean loggedIn) {
+        if (loggedIn) {
+            helper = new LocalServiceTestHelper(new LocalUserServiceTestConfig()).setEnvIsLoggedIn(loggedIn);
+        }
+        else {
+            helper = new LocalServiceTestHelper(new LocalUserServiceTestConfig()).setEnvIsLoggedIn(loggedIn);
+        }
+
+        helper.setUp();
+    }
+} 


### PR DESCRIPTION
Previously, there were no tests for the login/logout functionality. This commit adds those tests by separating out the logic of the doGet() function in the /login servlet into another function getAuthentication(). This getAuthentication() function is tested via JUnit for correctness by creating an expected return in the LoginTest.java file.

For clarification, the Login.java and Authentication.java files are moved into sps/login so that they are in the same package and can be easily accessed by the JUnit tests in LoginTest.java. Additionally, a number of necessary dependencies for appengine testing are added to the pom.xml file.

NOTE: this PR includes the comments left on [PR19](https://github.com/googleinterns/step118-2020/pull/19)