### PR TITLE
Correct formatting error in Cron Job

### DIFF
--- a/src/main/webapp/WEB-INF/cron.yaml
+++ b/src/main/webapp/WEB-INF/cron.yaml
@@ -1,4 +1,4 @@
 cron:
-    - description: "Choose Daily Deed"
-    - url: /cronjob
-    - schedule: every 24 hours
+- description: "Selects Daily Deed"
+  url: /cronjob
+  schedule: every 24 hours


### PR DESCRIPTION
The previous formatting for the cron job leads to a build error. This PR fixes that error.