### PR TITLE
Fix deed format sergio

### DIFF
--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -18,8 +18,9 @@
     </h1>
     <div class="date_deedContainer">
       <p class="goodDeedTitle" id="curDate">
-      <p class="goodDeedTitle" id="good-deed-title">
+      <p class="goodDeedTitle">Welcome User!</p>
     </div>
-    <p class="goodDeed"id="good-deed">
+    <p class="goodDeed" id="good-deed-title">
+    <p class="goodDeedDes" id="good-deed">
   </body>
 </html>

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -44,6 +44,15 @@
     bottom: 45px;
 }
 
+.goodDeedDes {
+    position: relative;
+    text-align: center;
+    font-family: roboto;
+    font-size: 18px;
+    color: rgb(10, 132, 255);
+    bottom: 45px;
+}
+
 .goodDeedTitle {
     display:inline;
     font-family: roboto;


### PR DESCRIPTION
There was some misunderstanding on what the "good-deed" and "good-deed-title" fields of the GoodDeed class were so I unintentionally placed them awkwardly on the page. These commits change that, by putting the "good-deed-title", which is the actual good deed, in the middle of the page and the "good-deed", which is a description of the good deed, underneath it. 