### PR TITLE
Don't show logout button

### DIFF
--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -22,9 +22,12 @@ function onLoad() {
 function checkLogin() {
     fetch('/login').then(response => response.json()).then((login) => {
         if (login.loggedIn) {
+            // don't show logout button
+            /*
             document.getElementById('loginBtn').style.display = 'none';
             document.getElementById('logoutBtn').style.display = 'block';
             document.getElementById('logoutBtn').href = login.redirectLink;
+            */
         }
         else {
             document.getElementById('loginBtn').href = login.redirectLink;


### PR DESCRIPTION
Due to an issue on the Users API, when deployed, the logout button logs users out of all of their Google accounts on all of their platforms. This commit keeps the logout button hidden so that users are unable to logout.