### PR TITLE
Resolve pom.xml conflicts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,20 +72,6 @@
 
     <dependency>
         <groupId>com.google.appengine</groupId>
-        <artifactId>appengine-testing</artifactId>
-        <version>1.9.64</version>
-        <scope>test</scope>
-    </dependency>
-
-    <dependency>
-        <groupId>com.google.appengine</groupId>
-        <artifactId>appengine-api-stubs</artifactId>
-        <version>1.9.64</version>
-        <scope>test</scope>
-    </dependency>
-
-    <dependency>
-        <groupId>com.google.appengine</groupId>
         <artifactId>appengine-tools-sdk</artifactId>
         <version>1.9.64</version>
         <scope>test</scope>
@@ -96,12 +82,6 @@
         <artifactId>google-api-client-appengine</artifactId>
         <version>1.23.0</version>
         <scope>test</scope>
-    </dependency>
-    
-    <dependency>
-        <groupId>org.mockito</groupId>
-        <artifactId>mockito-core</artifactId>
-        <version>2.22.0</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Previously, the appengine-api-stubs and appengine-testing dependencies were defined twice because they were merged in separately and used different versions. This commit resolves the duplicate defined dependencies and keeps the newer versions (1.9.80).