### PR TITLE
Add Past Deed Functionality

### DIFF
--- a/src/main/java/com/google/sps/PastDeeds/PastDeedsServlet.java
+++ b/src/main/java/com/google/sps/PastDeeds/PastDeedsServlet.java
@@ -38,7 +38,7 @@ import java.util.ArrayList;
 
 import com.google.sps.testing.GoodDeed;
 
-@WebServlet("/ghost-of-deed-past")
+@WebServlet("/ghost-of-deeds-past")
 public class PastDeedsServlet extends HttpServlet {
     private static final String FALSE = "false";
     private static final String TRUE = "true";

--- a/src/main/java/com/google/sps/PastDeeds/PastDeedsServlet.java
+++ b/src/main/java/com/google/sps/PastDeeds/PastDeedsServlet.java
@@ -48,11 +48,12 @@ public class PastDeedsServlet extends HttpServlet {
     private static final String POSTED_YET = "Posted Yet";
     private static final String LINK = "Link";
     private static final String TIME_STAMP = "Timestamp";
+    private static final List<GoodDeed> = deeds;
 
     @Override
     public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
         // Fetch Posted Deeds
-        List<GoodDeed> deeds = fetchPostedDeeds();
+        deeds = fetchPostedDeeds();
 
         Gson gson = new Gson();
         response.setContentType("application/json");

--- a/src/main/java/com/google/sps/PastDeeds/PastDeedsServlet.java
+++ b/src/main/java/com/google/sps/PastDeeds/PastDeedsServlet.java
@@ -1,0 +1,89 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.sps.testing;
+
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.EntityNotFoundException;
+import com.google.appengine.api.datastore.PreparedQuery;
+import com.google.appengine.api.datastore.Query;
+import com.google.appengine.api.datastore.Query.Filter;
+import com.google.appengine.api.datastore.Query.FilterOperator;
+import com.google.appengine.api.datastore.Query.FilterPredicate;
+import com.google.appengine.api.datastore.Key;
+
+import com.google.gson.Gson;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.ArrayList;
+
+import com.google.sps.testing.GoodDeed;
+
+@WebServlet("/ghost-of-deed-past")
+public class PastDeedsServlet extends HttpServlet {
+    private static final String FALSE = "false";
+    private static final String TRUE = "true";
+    private static final String GOOD_DEED = "GoodDeed";
+    private static final String NAME = "Name";
+    private static final String DESCRIPTION = "Description";
+    private static final String POSTED_YET = "Posted Yet";
+    private static final String LINK = "Link";
+    private static final String TIME_STAMP = "Timestamp";
+
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        // Fetch Posted Deeds
+        List<GoodDeed> deeds = fetchPostedDeeds();
+
+        Gson gson = new Gson();
+        response.setContentType("application/json");
+        response.getWriter().println(gson.toJson(deeds));
+
+    }
+
+    List<GoodDeed> fetchPostedDeeds() {
+        DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+
+        Filter posted_yet = new FilterPredicate(POSTED_YET, FilterOperator.EQUAL, TRUE);
+        Query query = new Query(GOOD_DEED).setFilter(posted_yet);
+
+        PreparedQuery results = datastore.prepare(query);
+
+        List<GoodDeed> deeds = new ArrayList<>();
+
+        for (Entity deed : results.asIterable()) {
+            Key key = deed.getKey();
+            long  id =  deed.getKey().getId();
+            String title = (String) deed.getProperty(NAME);
+            String description = (String) deed.getProperty(DESCRIPTION);
+            String posted_yet_string = (String) deed.getProperty(POSTED_YET);
+            boolean posted_yet_bool = Boolean.parseBoolean(posted_yet_string);
+            long timestamp = (long) deed.getProperty(TIME_STAMP);
+            String link = (String) deed.getProperty(LINK);
+
+            GoodDeed deedObject = new GoodDeed(key, id, title, description, posted_yet_bool, timestamp, link);
+            deeds.add(deedObject);
+        }
+
+        return deeds;
+    }
+}

--- a/src/main/webapp/WEB-INF/cron.yaml
+++ b/src/main/webapp/WEB-INF/cron.yaml
@@ -2,7 +2,6 @@ cron:
 - description: "Selects Daily Deed"
   url: /cronjob
   schedule: every 24 hours
-
 - description: "Sends out Emails"
   url: /email_users_cron
   schedule: every 24 hours

--- a/src/main/webapp/WEB-INF/cron.yaml
+++ b/src/main/webapp/WEB-INF/cron.yaml
@@ -2,6 +2,7 @@ cron:
 - description: "Selects Daily Deed"
   url: /cronjob
   schedule: every 24 hours
+
 - description: "Sends out Emails"
   url: /email_users_cron
   schedule: every 24 hours

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -22,6 +22,9 @@
                     <li class="nav-item">
                         <a class="nav-link" href="/register.html">Register</a>
                     </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="/past-deeds.html">Past Deeds</a>
+                    </li>
                 </ul>
                 <form class="form-inline my-2 my-lg-0">
                     <a class="btn btn-outline-dark my-2 my-sm-0 link" type="submit" href="" id="loginBtn" role="button">Login here</a>

--- a/src/main/webapp/past-deeds.html
+++ b/src/main/webapp/past-deeds.html
@@ -5,9 +5,9 @@
         <title>1Deed1Day</title>
         <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css" integrity="sha384-9aIt2nRpC12Uk9gS9baDl411NQApFmC26EwAOH8WgZl5MYYxFfc+NcPb1dKGj7Sk" crossorigin="anonymous">
         <link rel="stylesheet" href="style.css">
-        <script src="script-register.js"></script>
+        <script src="past-deeds.js"></script>
     </head>
-    <body onload="onLoad()">
+    <body onload="displayPastDeeds()" class="background">
         <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
             <a class="navbar-brand" href="/">1Deed1Day</a>
             <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
@@ -19,11 +19,11 @@
                     <li class="nav-item">
                         <a class="nav-link" href="/">Home</a>
                     </li>
-                    <li class="nav-item active">
-                        <a class="nav-link" href="#">Register <span class="sr-only">(current)</span></a>
-                    </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="/past-deeds.html">Past Deeds</a>
+                        <a class="nav-link" href="/register.html">Register</a>
+                    </li>
+                    <li class="nav-item active">
+                        <a class="nav-link" href="#">Past Deeds<span class="sr-only">(current)</span></a>
                     </li>
                 </ul>
                 <form class="form-inline my-2 my-lg-0">
@@ -32,26 +32,12 @@
                 </form>
             </div>
         </nav>
-        <main class="content">
-            <h1>Registration</h1>
-            <p>Please enter your name and email to register! You'll login with your email account.</p>
-            <div class="alert alert-danger" role="alert" id="register-error-alert" style="display: none;">
+        <main>
+            <div class="landing">
+                <ul id="deed-list"></ul>
             </div>
-            <div class="alert alert-success" role="alert" id="register-confirm" style="display: none;">
-                Login <a href="" class="alert-link" id="register-confirm-link">here</a> to start doing good deeds!
-            </div>
-            <form>
-                <div class="form-group">
-                    <label for="name">Name</label>
-                    <input type="text" class="form-control" id="name" name="name">
-                </div>
-                <div class="form-group">
-                    <label for="email">Email address</label>
-                    <input type="email" class="form-control" id="email" name="email">
-                </div>
-                <button type="button" class="btn btn-primary" onclick="submitRegistration()">Register</button>
-            </form>
         </main>
+        
         <!-- jquery scripts for bootstrap -->
         <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
         <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>

--- a/src/main/webapp/past-deeds.js
+++ b/src/main/webapp/past-deeds.js
@@ -1,0 +1,78 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+function displayPastDeeds() {
+    const deedList = document.getElementById("deed-list");
+    
+    fetch('/ghost-of-deed-past').then(response => response.json()).then(deeds => {
+        if (deeds.length == 0) {
+            deedList.innerText = "There are no pasts deeds to display";
+        }
+        else {
+            deeds.forEach(deed => {
+                deedList.appendChild(createDeedElement(deed));
+            })
+        }
+    });
+}
+
+function createDeedElement(deed) {
+    const deedElement = document.createElement('div');
+    deedElement.className = 'card bg-light mb-3 deedCard';
+
+    const cardHeader = document.createElement('div');
+    cardHeader.className = 'card-header';
+    cardHeader.innerText = 'Previous Deed';
+    
+    const cardBody = document.createElement('div');
+    cardBody.className = 'card-body';
+    
+    const titleElement = document.createElement('h5');
+    titleElement.className = 'card-title goodDeedTitle';
+    titleElement.innerText = deed.title;
+
+    const descriptionElement = document.createElement('p');
+    descriptionElement.className = 'card-text goodDeeddes';
+    descriptionElement.innerText = deed.description;
+
+    const cardFooter = document.createElement('div');
+    cardFooter.className = 'card-footer';
+
+    if (deed.link != "null") {
+        const linkButtonElement = document.createElement('button');
+        
+        linkButtonElement.classList.add('card-link');
+        linkButtonElement.className = 'btn btn-outline-dark';
+        linkButtonElement.innerText = 'Associated Link';
+
+        linkButtonElement.addEventListener('click', () => {
+            getLink(deed);
+        });
+
+        cardFooter.appendChild(linkButtonElement);
+    }
+
+    cardBody.appendChild(titleElement);
+    cardBody.appendChild(descriptionElement);
+
+    deedElement.appendChild(cardHeader);
+    deedElement.appendChild(cardBody)
+    deedElement.appendChild(cardFooter);
+
+    return deedElement;
+}
+
+function getLink(deed) {
+    window.location.href = deed.link;
+}

--- a/src/main/webapp/past-deeds.js
+++ b/src/main/webapp/past-deeds.js
@@ -12,51 +12,78 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-function displayPastDeeds() {
-    const deedList = document.getElementById("deed-list");
-    
-    fetch('/ghost-of-deed-past').then(response => response.json()).then(deeds => {
-        if (deeds.length == 0) {
-            deedList.innerText = "There are no pasts deeds to display";
+async function displayPastDeeds() {
+    const DEED_LIST = "deed-list";
+    const DEED_URL = "/ghost-of-deeds-past";
+    const NO_DEEDS_MESSAGE = "There are no pasts deeds to display";
+
+    const deedList = document.getElementById(DEED_LIST);
+
+    const response = await fetch(DEED_URL);
+    const deeds = await response.json();
+
+    if (deeds.length == 0) {
+            deedList.innerText = NO_DEEDS_MESSAGE;
         }
-        else {
-            deeds.forEach(deed => {
-                deedList.appendChild(createDeedElement(deed));
-            })
-        }
-    });
+    else {
+        deeds.forEach(deed => {
+            deedList.appendChild(createDeedElement(deed));
+        })
+    }
+
 }
 
 function createDeedElement(deed) {
-    const deedElement = document.createElement('div');
-    deedElement.className = 'card bg-light mb-3 deedCard';
+    const DIV = "div";
+    const H5 = "h5";
+    const P = "p";
+    const BUTTON = "button";
+    const CLICK = 'click';
 
-    const cardHeader = document.createElement('div');
-    cardHeader.className = 'card-header';
-    cardHeader.innerText = 'Previous Deed';
+    const CLASS_CARD = "card bg-light mb-3 deedCard";
+    const CLASS_HEADER = 'card-header';
+    const CLASS_BODY = 'card-body';
+    const CLASS_TITLE = 'card-title goodDeedTitle';
+    const CLASS_DES = 'card-text goodDeeddes';
+    const CLASS_FOOTER = 'card-footer';
+    const CLASS_LINK = 'card-link';
+    const CLASS_BUTTON = 'btn btn-outline-dark';
+
+    const HEADER_TEXT = 'Previous Deed';
+    const LINK_BUTTON_TEXT = 'Associated Link';
+
+    const NULL = "null";
+
+
+    const deedElement = document.createElement(DIV);
+    deedElement.className = CLASS_CARD;
+
+    const cardHeader = document.createElement(DIV);
+    cardHeader.className = CLASS_HEADER;
+    cardHeader.innerText = HEADER_TEXT;
     
-    const cardBody = document.createElement('div');
-    cardBody.className = 'card-body';
+    const cardBody = document.createElement(DIV);
+    cardBody.className = CLASS_BODY;
     
-    const titleElement = document.createElement('h5');
-    titleElement.className = 'card-title goodDeedTitle';
+    const titleElement = document.createElement(H5);
+    titleElement.className = CLASS_TITLE;
     titleElement.innerText = deed.title;
 
-    const descriptionElement = document.createElement('p');
-    descriptionElement.className = 'card-text goodDeeddes';
+    const descriptionElement = document.createElement(P);
+    descriptionElement.className = CLASS_DES;
     descriptionElement.innerText = deed.description;
 
-    const cardFooter = document.createElement('div');
-    cardFooter.className = 'card-footer';
+    const cardFooter = document.createElement(DIV);
+    cardFooter.className = CLASS_FOOTER;
 
-    if (deed.link != "null") {
-        const linkButtonElement = document.createElement('button');
+    if (deed.link != NULL) {
+        const linkButtonElement = document.createElement(BUTTON);
         
-        linkButtonElement.classList.add('card-link');
-        linkButtonElement.className = 'btn btn-outline-dark';
-        linkButtonElement.innerText = 'Associated Link';
+        linkButtonElement.classList.add(CLASS_LINK);
+        linkButtonElement.className = CLASS_BUTTON;
+        linkButtonElement.innerText = LINK_BUTTON_TEXT;
 
-        linkButtonElement.addEventListener('click', () => {
+        linkButtonElement.addEventListener(CLICK, () => {
             getLink(deed);
         });
 
@@ -75,4 +102,10 @@ function createDeedElement(deed) {
 
 function getLink(deed) {
     window.location.href = deed.link;
+}
+
+module.exports = {
+    displayPastDeeds: displayPastDeeds,
+    createDeedElement: createDeedElement,
+    getLink: getLink
 }

--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -65,7 +65,6 @@ async function displayDailyDeed() {
         link: either an associated link, or "null"
     }
     */
-    //console.log(daily_deed);
 
     const deedTitle = document.getElementById(DEED_TITLE_ID);
     const deedDescription = document.getElementById(DEED_DESCRIPTION_ID);

--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -65,7 +65,7 @@ async function displayDailyDeed() {
         link: either an associated link, or "null"
     }
     */
-    console.log(daily_deed);
+    //console.log(daily_deed);
 
     const deedTitle = document.getElementById(DEED_TITLE_ID);
     const deedDescription = document.getElementById(DEED_DESCRIPTION_ID);

--- a/src/test/java/com/google/sps/PastDeeds/PastDeedTesting.java
+++ b/src/test/java/com/google/sps/PastDeeds/PastDeedTesting.java
@@ -148,7 +148,7 @@ public class PastDeedTesting {
         StringWriter sw = new StringWriter();
         PrintWriter pw = new PrintWriter(sw);
 
-        Mockito.doReturn(pw).when(response).getWriter();
+        Mockito.thenReturn(pw).when(response).getWriter();
 
         Gson gson = new Gson();
 

--- a/src/test/java/com/google/sps/PastDeeds/PastDeedTesting.java
+++ b/src/test/java/com/google/sps/PastDeeds/PastDeedTesting.java
@@ -1,0 +1,166 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.sps.testing;
+
+import static com.google.appengine.api.datastore.FetchOptions.Builder.withLimit;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.mock;
+import org.mockito.Mockito;
+
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import java.util.List;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import com.google.gson.Gson;
+
+import com.google.appengine.api.datastore.Key;
+import com.google.appengine.api.datastore.KeyFactory;
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.Query;
+import com.google.appengine.api.datastore.Query.Filter;
+import com.google.appengine.api.datastore.Query.FilterOperator;
+import com.google.appengine.api.datastore.Query.FilterPredicate;
+import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
+import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+
+import com.google.sps.testing.GoodDeed;
+import com.google.sps.testing.PastDeedsServlet;
+
+@RunWith(JUnit4.class)
+public class PastDeedTesting {
+    // Deed Properties
+    private static final String GOOD_DEED = "GoodDeed";
+    private static final String NAME = "Name";
+    private static final String DESCRIPTION = "Description";
+    private static final String POSTED_YET = "Posted Yet";
+    private static final String DAILY_DEED = "Daily Deed";
+    private static final String TIMESTAMP = "Timestamp";
+    private static final String LINK = "Link";
+
+    // Property Inputs
+    private static final String TITLE = "Deed Name";
+    private static final String DESCRIPTION_INPUT = "Deed Description";
+    private static final String TRUE_STRING = "true";
+    private static final String FALSE_STRING = "false";
+    private static final long TIMESTAMP_INPUT = 67890;
+    private static final boolean TRUE = true;
+    private static final boolean FALSE = false;
+
+    private PastDeedsServlet pdServlet;
+
+    private final LocalServiceTestHelper helper = 
+        new LocalServiceTestHelper( new LocalDatastoreServiceTestConfig());
+    
+    @Before
+    public void setUp() {
+        helper.setUp();
+        pdServlet = new PastDeedsServlet();
+    }
+
+    @Test
+    public void testFetchPosted() {
+        DatastoreService ds = DatastoreServiceFactory.getDatastoreService();
+
+        Entity postedEntity = new Entity(GOOD_DEED);
+        postedEntity.setProperty(NAME, TITLE);
+        postedEntity.setProperty(DESCRIPTION, DESCRIPTION_INPUT);
+        postedEntity.setProperty(POSTED_YET, TRUE_STRING);
+        postedEntity.setProperty(DAILY_DEED, FALSE_STRING);
+        postedEntity.setProperty(TIMESTAMP, TIMESTAMP_INPUT);
+        postedEntity.setProperty(LINK, LINK);
+        ds.put(postedEntity);
+
+        Entity not_Posted_Entity = new Entity(GOOD_DEED);
+        not_Posted_Entity.setProperty(NAME, TITLE);
+        not_Posted_Entity.setProperty(DESCRIPTION, DESCRIPTION_INPUT);
+        not_Posted_Entity.setProperty(POSTED_YET, FALSE_STRING);
+        not_Posted_Entity.setProperty(DAILY_DEED, FALSE_STRING);
+        not_Posted_Entity.setProperty(TIMESTAMP, TIMESTAMP_INPUT);
+        not_Posted_Entity.setProperty(LINK, LINK);
+        ds.put(not_Posted_Entity);
+
+        GoodDeed posted_deed = 
+            new GoodDeed(postedEntity.getKey(), postedEntity.getKey().getId(), TITLE, DESCRIPTION_INPUT, TRUE, TIMESTAMP_INPUT, LINK);
+        GoodDeed not_posted_deed = 
+            new GoodDeed(not_Posted_Entity.getKey(), not_Posted_Entity.getKey().getId(), TITLE, DESCRIPTION_INPUT, FALSE, TIMESTAMP_INPUT, LINK);
+        
+        List<GoodDeed> actual = pdServlet.fetchPostedDeeds();
+
+        Assert.assertEquals(1, actual.size());
+        Assert.assertEquals(posted_deed.getKey(), actual.get(0).getKey());
+    }
+
+    @Test
+    public void testDoGet() throws IOException {
+        DatastoreService ds = DatastoreServiceFactory.getDatastoreService();
+
+        Entity postedEntity = new Entity(GOOD_DEED);
+        postedEntity.setProperty(NAME, TITLE);
+        postedEntity.setProperty(DESCRIPTION, DESCRIPTION_INPUT);
+        postedEntity.setProperty(POSTED_YET, TRUE_STRING);
+        postedEntity.setProperty(DAILY_DEED, FALSE_STRING);
+        postedEntity.setProperty(TIMESTAMP, TIMESTAMP_INPUT);
+        postedEntity.setProperty(LINK, LINK);
+        ds.put(postedEntity);
+
+        Entity not_Posted_Entity = new Entity(GOOD_DEED);
+        not_Posted_Entity.setProperty(NAME, TITLE);
+        not_Posted_Entity.setProperty(DESCRIPTION, DESCRIPTION_INPUT);
+        not_Posted_Entity.setProperty(POSTED_YET, FALSE_STRING);
+        not_Posted_Entity.setProperty(DAILY_DEED, FALSE_STRING);
+        not_Posted_Entity.setProperty(TIMESTAMP, TIMESTAMP_INPUT);
+        not_Posted_Entity.setProperty(LINK, LINK);
+        ds.put(not_Posted_Entity);
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+
+        Mockito.doReturn(pw).when(response).getWriter();
+
+        Gson gson = new Gson();
+
+        GoodDeed posted_deed = 
+            new GoodDeed(postedEntity.getKey(), postedEntity.getKey().getId(), TITLE, DESCRIPTION_INPUT, TRUE, TIMESTAMP_INPUT, LINK);
+        
+        List<GoodDeed> expected = new ArrayList<>();
+        expected.add(posted_deed);
+        
+        pdServlet.doGet(request, response);
+        String actual = sw.getBuffer().toString().trim();
+
+        Assert.assertEquals(actual, gson.toJson(expected));
+    }
+}

--- a/src/test/javascript/display-deed.test.js
+++ b/src/test/javascript/display-deed.test.js
@@ -63,21 +63,11 @@ test('Test getLink()', async () => {
         link: LINK_NOT_NULL
     }));
 
+    delete window.location;
+    window.location = Object.create(window);
+    window.location.href = 'null';
+
     return scriptMain.getLink().then(response => {
-        global.window = Object.create(window);
-        Object.defineProperty(window, 'location', {
-            value: {
-                href: LINK_NOT_NULL
-            }
-        });
         expect(window.location.href).toEqual(LINK_NOT_NULL);
     })
-
-    
-    
-    
-    
-    
-    
-    
 })

--- a/src/test/javascript/past-deeds.test.js
+++ b/src/test/javascript/past-deeds.test.js
@@ -1,0 +1,191 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const script = require('../../main/webapp/past-deeds')
+
+const TITLE = "title";
+const DESCRIPTION = "description";
+const LINK_NULL = "null";
+const LINK_NOT_NULL = "https://www.google.com/";
+
+const DIV = "div";
+const H5 = "h5";
+const P = "p";
+const BUTTON = "button";
+const CLICK = 'click';
+
+const CLASS_CARD = "card bg-light mb-3 deedCard";
+const CLASS_HEADER = 'card-header';
+const CLASS_BODY = 'card-body';
+const CLASS_TITLE = 'card-title goodDeedTitle';
+const CLASS_DES = 'card-text goodDeeddes';
+const CLASS_FOOTER = 'card-footer';
+const CLASS_LINK = 'card-link';
+const CLASS_BUTTON = 'btn btn-outline-dark';
+
+const HEADER_TEXT = 'Previous Deed';
+const LINK_BUTTON_TEXT = 'Associated Link';
+
+const DEED_LIST = "deed-list";
+const FETCH_URL = "/ghost-of-deeds-past";
+const NO_DEEDS_TEXT = "There are no pasts deeds to display";
+
+const DUMMY_HTML = "<ul id ='deed-list'></ul>";
+
+beforeEach(() => {
+    fetch.resetMocks();
+})
+
+
+test("Test getLink(deed)", () => {
+    const deed = {link: LINK_NOT_NULL};
+    
+    delete window.location;
+    window.location = Object.create(window);
+    window.location.href = LINK_NULL;
+
+    script.getLink(deed);
+
+    expect(window.location.href).toEqual(LINK_NOT_NULL);
+})
+
+test("Test createDeedElement(deed) link null", () => {
+    const deed = {title: TITLE, description: DESCRIPTION, link: LINK_NULL};
+    
+    // Generate Deed Element maunally
+    const deedElement = document.createElement(DIV);
+    deedElement.className = CLASS_CARD;
+
+    const cardHeader = document.createElement(DIV);
+    cardHeader.className = CLASS_HEADER;
+    cardHeader.innerText = HEADER_TEXT;
+    
+    const cardBody = document.createElement(DIV);
+    cardBody.className = CLASS_BODY;
+    
+    const titleElement = document.createElement(H5);
+    titleElement.className = CLASS_TITLE;
+    titleElement.innerText = deed.title;
+
+    const descriptionElement = document.createElement(P);
+    descriptionElement.className = CLASS_DES;
+    descriptionElement.innerText = deed.description;
+
+    const cardFooter = document.createElement(DIV);
+    cardFooter.className = CLASS_FOOTER;
+
+    cardBody.appendChild(titleElement);
+    cardBody.appendChild(descriptionElement);
+
+    deedElement.appendChild(cardHeader);
+    deedElement.appendChild(cardBody)
+    deedElement.appendChild(cardFooter);
+    
+    // Call function
+    const actualElement = script.createDeedElement(deed);
+
+    expect(deedElement.isEqualNode(actualElement)).toBe(true);
+
+})
+
+test("Test createDeedElement(deed) link not null", () => {
+    const deed = {title: TITLE, description: DESCRIPTION, link: LINK_NOT_NULL};
+    
+    
+    // Generate Deed Element maunally
+    const deedElement = document.createElement(DIV);
+    deedElement.className = CLASS_CARD;
+
+    const cardHeader = document.createElement(DIV);
+    cardHeader.className = CLASS_HEADER;
+    cardHeader.innerText = HEADER_TEXT;
+    
+    const cardBody = document.createElement(DIV);
+    cardBody.className = CLASS_BODY;
+    
+    const titleElement = document.createElement(H5);
+    titleElement.className = CLASS_TITLE;
+    titleElement.innerText = deed.title;
+
+    const descriptionElement = document.createElement(P);
+    descriptionElement.className = CLASS_DES;
+    descriptionElement.innerText = deed.description;
+
+    const cardFooter = document.createElement(DIV);
+    cardFooter.className = CLASS_FOOTER;
+
+    const linkButtonElement = document.createElement(BUTTON);
+        
+    linkButtonElement.classList.add(CLASS_LINK);
+    linkButtonElement.className = CLASS_BUTTON;
+    linkButtonElement.innerText = LINK_BUTTON_TEXT;
+
+    linkButtonElement.addEventListener(CLICK, () => {
+        script.getLink(deed);
+    });
+
+    cardFooter.appendChild(linkButtonElement);
+
+    cardBody.appendChild(titleElement);
+    cardBody.appendChild(descriptionElement);
+
+    deedElement.appendChild(cardHeader);
+    deedElement.appendChild(cardBody)
+    deedElement.appendChild(cardFooter);
+    
+    // Call function
+    const actualElement = script.createDeedElement(deed);
+
+    expect(deedElement.isEqualNode(actualElement)).toBe(true);
+
+})
+
+test("test displayPastDeeds() w/ 1 deed", async () => {
+    const deed = [{
+        title: TITLE,
+        description: DESCRIPTION,
+        link: LINK_NOT_NULL
+    }];
+    
+    fetch.mockResponseOnce(JSON.stringify(deed));
+
+    document.body.innerHTML = DUMMY_HTML;
+
+    const deedElement = script.createDeedElement(deed[0]);
+    const deed_list = document.getElementById(DEED_LIST);
+
+    return script.displayPastDeeds().then(response => {
+        const child = document.getElementById(DEED_LIST).getElementsByClassName(CLASS_CARD)[0];
+        
+        expect(fetch).toHaveBeenCalledTimes(1);
+        expect(fetch).toHaveBeenCalledWith(FETCH_URL);
+        expect(child.isEqualNode(deedElement)).toBe(true);
+    });
+})
+
+test("test displayPastDeeds() w/ no deed", async () => {
+    const deed = [];
+
+    fetch.mockResponseOnce(JSON.stringify(deed));
+
+    document.body.innerHTML = DUMMY_HTML;
+
+    return script.displayPastDeeds().then(response => {        
+        const deed_list = document.getElementById(DEED_LIST);
+
+        expect(fetch).toHaveBeenCalledTimes(1);
+        expect(fetch).toHaveBeenCalledWith(FETCH_URL);
+        expect(deed_list.innerText).toBe(NO_DEEDS_TEXT);
+    });
+})


### PR DESCRIPTION
Currently, there is no way to view past deeds, so you only have to option to complete the designated Daily Deed. This PR adds the ability to view any deed that has been previously displayed. 
When the past-deeds.html page is accessed, JS sends a fetch request to the servlet. The servlet pulls all Deed Objects where "Posted Yet" = "true" from the database, and sends them to JS. From there a deed-card (similar to the one displayed on the main page) is created for each GoodDeed object in the list. If the list is empty, it simply displays a "There are no past deeds" message.