### PR TITLE
Remove did deed button and reload after profle update

### DIFF
--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -61,7 +61,6 @@
                     </div>
                     <div class="card-footer">
                         <a class="btn btn-outline-dark" role="button" href="#" class="card-link" id="associated-link" onclick="getLink()">Associated link</a>
-                        <a class="btn btn-dark" role="button" href="#" class="card-link" id="did-deed">Did the deed!</a>
                     </div>
                 </div>
             </div>

--- a/src/main/webapp/profile.html
+++ b/src/main/webapp/profile.html
@@ -66,7 +66,7 @@
                     <label for="bio">Bio</label>
                     <textarea class="form-control" id="bio" name="bio"></textarea>
                 </div>
-                <button type="button" class="btn btn-primary" onclick="updateProfile()">Update</button>
+                <button type="submit" class="btn btn-primary" onclick="updateProfile()">Update</button>
             </form>
         </main>
 


### PR DESCRIPTION
Previously, there was a did deed button on the homepage and after profile updates, there would be no reload. Because the did deed functionality was unable to be implemented in the timeframe and the lack of reload makes it unclear whether the profile was updated, this commit removes the did deed button and reloads the page after a profile update.