### PR TITLE
Remove duplicate login from navbar

### DIFF
--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -30,9 +30,6 @@
                         <a class="nav-link" href="/register.html">Register</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="/login.html">Login</a>
-                    </li>
-                    <li class="nav-item">
                         <a class="nav-link" href="/profile.html">Profile</a>
                     </li>
                     <li class="nav-item">

--- a/src/main/webapp/login.html
+++ b/src/main/webapp/login.html
@@ -32,9 +32,6 @@
                     <li class="nav-item">
                         <a class="nav-link" href="/register.html">Register</span></a>
                     </li>
-                    <li class="nav-item active">
-                        <a class="nav-link" href="#">Login <span class="sr-only">(current)</a>
-                    </li>
                     <li class="nav-item">
                         <a class="nav-link" href="/profile.html">Profile</a>
                     </li>

--- a/src/main/webapp/past-deeds.html
+++ b/src/main/webapp/past-deeds.html
@@ -23,9 +23,6 @@
                         <a class="nav-link" href="/register.html">Register</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="/login.html">Login</a>
-                    </li>
-                    <li class="nav-item">
                         <a class="nav-link" href="/profile.html">Profile</a>
                     </li>
                     <li class="nav-item active">

--- a/src/main/webapp/profile.html
+++ b/src/main/webapp/profile.html
@@ -29,9 +29,6 @@
                     <li class="nav-item">
                         <a class="nav-link" href="/register.html">Register</a>
                     </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="/login.html">Login</a>
-                    </li>
                     <li class="nav-item active">
                         <a class="nav-link" href="#">Profile <span class="sr-only">(current)</span></a>
                     </li>

--- a/src/main/webapp/register.html
+++ b/src/main/webapp/register.html
@@ -30,9 +30,6 @@
                         <a class="nav-link" href="#">Register <span class="sr-only">(current)</span></a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="/login.html">Login</a>
-                    </li>
-                    <li class="nav-item">
                         <a class="nav-link" href="/profile.html">Profile</a>
                     </li>
                     <li class="nav-item">

--- a/src/main/webapp/surveyInput.html
+++ b/src/main/webapp/surveyInput.html
@@ -23,9 +23,6 @@
                         <a class="nav-link" href="/register.html">Register</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="/login.html">Login</a>
-                    </li>
-                    <li class="nav-item">
                         <a class="nav-link" href="/profile.html">Profile</a>
                     </li>
                     <li class="nav-item">


### PR DESCRIPTION
Previously, login was shown in both the navbar on the left side and the right side. This commit removes the duplicate display of the login link.