### PR TITLE
Update query in Email to search for Profile not User

### DIFF
--- a/src/main/java/com/google/sps/email/EmailServlet.java
+++ b/src/main/java/com/google/sps/email/EmailServlet.java
@@ -140,7 +140,7 @@ public class EmailServlet extends HttpServlet {
 
         DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
 
-        Query query = new Query("User");
+        Query query = new Query("Profile");
         PreparedQuery prep_query = datastore.prepare(query);
 
         for (Entity user : prep_query.asIterable()) {

--- a/src/test/java/com/google/sps/email/EmailTesting.java
+++ b/src/test/java/com/google/sps/email/EmailTesting.java
@@ -58,7 +58,7 @@ import com.google.sps.testing.GoodDeed;
 public class EmailTesting {
     private EmailServlet emailServlet;
 
-    private static final String USER = "User";
+    private static final String USER = "Profile";
     private static final String EMAIL = "email";
     private static final String EMAIL_INPUT = "test@gmail.com";
     private static final String EMAIL_SUBJECT = "Complete your daily deed";


### PR DESCRIPTION
Email and EmailTesting were searching for "User" which didn't exist. It now queries for "Profile", so emails will send properly.